### PR TITLE
Add ref support

### DIFF
--- a/xsd.go
+++ b/xsd.go
@@ -87,6 +87,7 @@ type xsdImport struct {
 type xsdElement struct {
 	Name        string          `xml:"name,attr"`
 	Type        string          `xml:"type,attr"`
+	Ref         string          `xml:"ref,attr"`
 	Default     string          `xml:"default,attr"`
 	Min         string          `xml:"minOccurs,attr"`
 	Max         string          `xml:"maxOccurs,attr"`
@@ -104,7 +105,7 @@ func (e xsdElement) omittable() bool {
 }
 
 func (e xsdElement) inlineType() bool {
-	return e.Type == ""
+	return e.Type == "" && e.Ref == ""
 }
 
 type xsdComplexType struct {


### PR DESCRIPTION
This PR adds element `ref` attribute support, resolves https://github.com/ivarg/goxsd/issues/6

Useful for XSDs generated by the Microsoft's `xsd.exe` tool